### PR TITLE
Fix file path loading in image IO with regression test

### DIFF
--- a/src/image_io.py
+++ b/src/image_io.py
@@ -9,6 +9,7 @@ Se utiliza Pillow para abrir imágenes y OpenCV/Numpy para la manipulación.
 from __future__ import annotations
 
 import io
+from pathlib import Path
 from typing import Tuple
 
 import cv2

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.image_io import load_image
+
+
+def test_load_image_from_path(tmp_path):
+    # Crear una imagen simple y guardarla
+    img = Image.new("RGB", (10, 10), color="red")
+    img_path = tmp_path / "img.png"
+    img.save(img_path)
+
+    # Cargar la imagen usando Path
+    arr = load_image(Path(img_path))
+
+    assert arr.shape == (10, 10, 3)
+    assert arr.dtype == np.uint8
+    # Canal rojo completo, verde y azul cero
+    assert np.all(arr[:, :, 0] == 255)
+    assert np.all(arr[:, :, 1:] == 0)


### PR DESCRIPTION
## Summary
- fix `load_image` by importing `Path` from `pathlib`
- add regression test for loading an image via `Path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0fc75f8508323a7683d8ca8ba2eeb